### PR TITLE
Add options to disable seen/caught requirements

### DIFF
--- a/src/main/java/org/ppvon/ultimateCobblemonProgression/common/progression/dex/DexProgressionListener.java
+++ b/src/main/java/org/ppvon/ultimateCobblemonProgression/common/progression/dex/DexProgressionListener.java
@@ -24,13 +24,19 @@ public final class DexProgressionListener {
     }
 
     private static Unit onDexChanged(PokedexDataChangedEvent event) {
-        if(!ConfigLoader.DO_DEX_PROGRESSION.get()) {
+        if (!ConfigLoader.DO_DEX_PROGRESSION.get()) {
             return Unit.INSTANCE;
         }
+
         AbstractPokedexManager manager = event.getPokedexManager();
 
-        int caughtCount = manager.getGlobalCalculatedValue(CaughtCount.INSTANCE);
-        int seenCount = manager.getGlobalCalculatedValue(SeenCount.INSTANCE);
+        int caughtCount = ConfigLoader.REQUIRE_DEX_CAUGHT.get()
+            ? manager.getGlobalCalculatedValue(CaughtCount.INSTANCE)
+            : 0;
+
+        int seenCount = ConfigLoader.REQUIRE_DEX_SEEN.get()
+            ? manager.getGlobalCalculatedValue(SeenCount.INSTANCE)
+            : 0;
 
         UUID playerUUID = event.getPlayerUUID();
         ServerPlayer player = getPlayer(playerUUID);
@@ -39,5 +45,6 @@ public final class DexProgressionListener {
         ProgressionManager.attemptLevelUp(player, seenCount, caughtCount);
 
         return Unit.INSTANCE;
-    }
+}
+
 }

--- a/src/main/java/org/ppvon/ultimateCobblemonProgression/config/CommonConfig.java
+++ b/src/main/java/org/ppvon/ultimateCobblemonProgression/config/CommonConfig.java
@@ -3,4 +3,6 @@ package org.ppvon.ultimateCobblemonProgression.config;
 public class CommonConfig {
     public boolean doLevelCap = true;
     public boolean doDexProgression = true;
+    public boolean requireDexSeen = true;
+    public boolean requireDexCaught = true;
 }

--- a/src/main/java/org/ppvon/ultimateCobblemonProgression/config/ConfigLoader.java
+++ b/src/main/java/org/ppvon/ultimateCobblemonProgression/config/ConfigLoader.java
@@ -26,7 +26,9 @@ public final class ConfigLoader {
     // ucp-common.json
     public static Supplier<Boolean> DO_LEVEL_CAP;
     public static Supplier<Boolean> DO_DEX_PROGRESSION;
-
+    public static Supplier<Boolean> REQUIRE_DEX_SEEN;
+    public static Supplier<Boolean> REQUIRE_DEX_CAUGHT;
+    
     private ConfigLoader() {}
 
     public static void init() {
@@ -63,6 +65,8 @@ public final class ConfigLoader {
 
         DO_LEVEL_CAP = () -> COMMON.doLevelCap;
         DO_DEX_PROGRESSION = () -> COMMON.doDexProgression;
+        REQUIRE_DEX_SEEN = () -> COMMON.requireDexSeen;
+        REQUIRE_DEX_CAUGHT = () -> COMMON.requireDexCaught;
     }
 
     public static SpawnConfig spawn() { return SPAWN; }


### PR DESCRIPTION
Hello! I just added 2 new params to config:
```
{
  "doLevelCap": true,
  "doDexProgression": true,
  "requireDexSeen": true,
  "requireDexCaught": true
}
```
requireDexSeen - when disabled, remove's requirement for scanning cobblemons (also from the `/trainerlevel get` command)
requireDexCaught - when disabled, remove's requirement for caughting cobblemons (also from the `/trainerlevel get` command)